### PR TITLE
fix: release subscriptions when clearing local signals

### DIFF
--- a/src/detail/local_signal_container.cpp
+++ b/src/detail/local_signal_container.cpp
@@ -54,6 +54,16 @@ unsigned wss::detail::local_signal_container::remove_local_signal(local_signal& 
 
 void wss::detail::local_signal_container::clear_local_signals()
 {
+    // Manually clean up the connections so that the local_signal objects can be safely
+    // destroyed without leaving dangling pointers in the signal handlers.
+    for (auto& entry : _signals)
+    {
+        auto& signal = entry.second;
+        signal->on_data_published.disconnect();
+        signal->on_metadata_changed.disconnect();
+        signal->holder.close();
+    }
+
     _signals.clear();
 }
 


### PR DESCRIPTION
clear_local_signals() only emptied the signal map. But subscribe() binds the data/metadata callbacks with a shared_ptr to the registered_local_signal (and shared_from_this() to the connection), so those slots keep both alive: the subscribe_holder never destructs, the signal's subscribe count never reaches zero, and on_unsubscribed never fires.

A connection that closes without first sending an explicit unsubscribe therefore leaks its holder and keeps the signal subscribed. Another connection's later unsubscribe can then never drop the count to zero, leaving the listener publishing data no one consumes.

Disconnect the data/metadata slots and close the holder for each signal before clearing the map, mirroring unsubscribe(). No-op for entries that were never subscribed.